### PR TITLE
Support OPENAI_API_KEY environment variable in plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,10 @@ python -m backend.app
 ```
 
 Open a browser at [http://localhost:5000](http://localhost:5000) to add new text entries. Collected data can be found in `data/dataset.json`.
+
+## OpenAI Configuration
+
+If you use the optional `plugins.model` helper, it can automatically detect
+an API key from the `OPENAI_API_KEY` environment variable when one is not
+explicitly provided. You may also use `env:VAR_NAME` notation to reference
+other environment variables when calling `connect`.

--- a/plugins/model.py
+++ b/plugins/model.py
@@ -1,0 +1,39 @@
+import os
+
+
+def connect(api_key: str | None = None) -> str:
+    """Return an API key for connecting to OpenAI.
+
+    The function first checks the ``api_key`` parameter. If it is ``None``,
+    ``OPENAI_API_KEY`` in the environment is used when available. The
+    parameter also supports ``env:VAR`` indirection, in which case the value of
+    the environment variable ``VAR`` is looked up.
+
+    Parameters
+    ----------
+    api_key:
+        Direct API key value or ``env:VAR`` indirection. If omitted, the
+        ``OPENAI_API_KEY`` environment variable is consulted.
+
+    Returns
+    -------
+    str
+        The API key that should be used when talking to OpenAI.
+    """
+
+    # If no API key was passed, fall back to the environment variable.
+    if api_key is None:
+        env_key = os.environ.get("OPENAI_API_KEY")
+        if env_key:
+            return env_key
+        raise ValueError("No OpenAI API key provided and OPENAI_API_KEY is not set")
+
+    # Support ``env:VAR`` indirection for explicit configuration.
+    if api_key.startswith("env:"):
+        env_name = api_key.split(":", 1)[1]
+        env_key = os.environ.get(env_name)
+        if env_key:
+            return env_key
+        raise ValueError(f"Environment variable '{env_name}' is not set")
+
+    return api_key

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,18 @@
+import sys
+import pathlib
+
+# Ensure repository root is importable
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from plugins import model
+
+
+def test_connect_uses_env_var(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "env-key")
+    assert model.connect() == "env-key"
+
+
+def test_connect_env_indirection(monkeypatch):
+    monkeypatch.setenv("CUSTOM_KEY", "other-key")
+    assert model.connect("env:CUSTOM_KEY") == "other-key"


### PR DESCRIPTION
## Summary
- add `plugins.model.connect` helper that automatically uses `OPENAI_API_KEY` env var
- document automatic API key detection and `env:` indirection
- add tests for environment variable and `env:` syntax handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689aecaf551c83308096f0a6f5c9ccab